### PR TITLE
Update log label when it fails to send and retry

### DIFF
--- a/firehose/firehose.go
+++ b/firehose/firehose.go
@@ -215,7 +215,7 @@ func (output *OutputPlugin) processAPIResponse(response *firehose.PutRecordBatch
 			return fmt.Errorf("PutRecordBatch request returned with no records successfully recieved")
 		}
 
-		logrus.Errorf("[firehose %d] %d records failed to be delivered\n", output.PluginID, aws.Int64Value(response.FailedPutCount))
+		logrus.Warnf("[firehose %d] %d records failed to be delivered. Will retry.\n", output.PluginID, aws.Int64Value(response.FailedPutCount))
 		failedRecords := make([]*firehose.Record, 0, aws.Int64Value(response.FailedPutCount))
 		// try to resend failed records
 		for i, record := range response.RequestResponses {


### PR DESCRIPTION
*Description of changes:*
When a request fails to send data to Kinesis Firehose, we print an error log and retry. In this change, we are updatring the label of the log from 'error' to 'warning', and also updating the log message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
