### PR TITLE
Call the Flush() for every plugin instances before exiting

### DIFF
--- a/fluent-bit-firehose.go
+++ b/fluent-bit-firehose.go
@@ -125,6 +125,14 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 
 //export FLBPluginExit
 func FLBPluginExit() int {
+	// Before final exit, call Flush() for all the instances of the Output Plugin
+	for i := range pluginInstances {
+		err := pluginInstances[i].Flush()
+		if err != nil {
+			logrus.Errorf("[firehose %d] %v\n", pluginInstances[i].PluginID, err)
+		}
+	}
+
 	return output.FLB_OK
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add double-check before the final exit to improve the reliability. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
