### PR TITLE
Implements milli- and microsecond time formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run `make` to build `./bin/firehose.so`. Then use with Fluent Bit:
 * `role_arn`: ARN of an IAM role to assume (for cross account access).
 * `endpoint`: Specify a custom endpoint for the Kinesis Firehose API.
 * `time_key`: Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis.
-* `time_key_format`: [strftime](http://man7.org/linux/man-pages/man3/strftime.3.html) compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. 
+* `time_key_format`: [strftime](http://man7.org/linux/man-pages/man3/strftime.3.html) compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. You can also use `%L` for milliseconds and `%f` for microseconds.
 
 ### Permissions
 

--- a/firehose/firehose.go
+++ b/firehose/firehose.go
@@ -92,7 +92,7 @@ func NewOutputPlugin(region, deliveryStream, dataKeys, roleARN, endpoint, timeKe
 		if timeFmt == "" {
 			timeFmt = defaultTimeFmt
 		}
-		timeFormatter, err = strftime.New(timeFmt)
+		timeFormatter, err = strftime.New(timeFmt, strftime.WithMilliseconds('L'), strftime.WithMicroseconds('f'))
 		if err != nil {
 			logrus.Errorf("[firehose %d] Issue with strftime format in 'time_key_format'", pluginID)
 			return nil, err

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/fluent/fluent-bit-go v0.0.0-20190614024040-c017a8579953
 	github.com/golang/mock v1.3.1
 	github.com/json-iterator/go v1.1.6
-	github.com/lestrrat-go/strftime v1.0.1
+	github.com/lestrrat-go/strftime v1.0.2-0.20200618102204-1b0bc59fa4ab
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc h1:RKf14vYWi2t
 github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc/go.mod h1:kopuH9ugFRkIXf3YoqHKyrJ9YfUFsckUU9S7B+XP+is=
 github.com/lestrrat-go/strftime v1.0.1 h1:o7qz5pmLzPDLyGW4lG6JvTKPUfTFXwe+vOamIYWtnVU=
 github.com/lestrrat-go/strftime v1.0.1/go.mod h1:E1nN3pCbtMSu1yjSVeyuRFVm/U0xoR76fd03sz+Qz4g=
+github.com/lestrrat-go/strftime v1.0.2-0.20200618102204-1b0bc59fa4ab h1:rJi8p3M7kABzb4Cw2JiUr01VwTPDc50CqKkn6CR6Si0=
+github.com/lestrrat-go/strftime v1.0.2-0.20200618102204-1b0bc59fa4ab/go.mod h1:E1nN3pCbtMSu1yjSVeyuRFVm/U0xoR76fd03sz+Qz4g=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=


### PR DESCRIPTION
Based on https://github.com/aws/amazon-kinesis-streams-for-fluent-bit/pull/35

*Issue #, if available:* 26

*Description of changes:* This PR is based on https://github.com/aws/amazon-kinesis-streams-for-fluent-bit/pull/35 and implements the milli- and microsecond specifications within strftime for time_format_key.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.