### PR TITLE
Enabling github actions

### DIFF
--- a/.github/build.yml
+++ b/.github/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.12
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.12
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      
+    - name: golint
+      run: go get -u golang.org/x/lint/golint
+ 
+    - name: Build
+      run: make build test

--- a/.github/build.yml
+++ b/.github/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ mainline ]
   pull_request:
-    branches: [ master ]
+    branches: [ mainline ]
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ mainline ]
   pull_request:
-    branches: [ master ]
+    branches: [ mainline ]
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Test Actions Status](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit/workflows/Build/badge.svg)](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit/actions)
 ## Fluent Bit Plugin for Amazon Kinesis Firehose
 
 A Fluent Bit output plugin for Amazon Kinesis Data Firehose.


### PR DESCRIPTION
Ignored lint on fluent-bit-firehose.go. 
Added build.yml in workflows for github actions.

![image](https://user-images.githubusercontent.com/21286441/87815751-06ae9b80-c81b-11ea-951b-4abfff16d037.png)

This test is from my version. It needs to be applied on mainline for testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
