### PR TITLE
Fix bug: Check for empty batch before sending

### DIFF
--- a/firehose/firehose.go
+++ b/firehose/firehose.go
@@ -235,6 +235,11 @@ func (output *OutputPlugin) processRecord(record map[interface{}]interface{}) ([
 }
 
 func (output *OutputPlugin) sendCurrentBatch() (int, error) {
+	// return if the batch is empty
+	if len(output.records) == 0 {
+		return fluentbit.FLB_OK, nil
+	}
+
 	output.timer.Check()
 
 	response, err := output.client.PutRecordBatch(&firehose.PutRecordBatchInput{

--- a/firehose/firehose_test.go
+++ b/firehose/firehose_test.go
@@ -89,3 +89,25 @@ func TestAddRecordAndFlush(t *testing.T) {
 	assert.Equal(t, retCode, fluentbit.FLB_OK, "Expected return code to be FLB_OK")
 
 }
+
+func TestSendCurrentBatch(t *testing.T) {
+	output := OutputPlugin{
+		region:         "us-east-1",
+		deliveryStream: "stream",
+		dataKeys:       "",
+		client:         nil,
+		records:        nil,
+	}
+
+	retCode, err := output.sendCurrentBatch()
+
+	assert.Equal(t, retCode, fluentbit.FLB_OK, "Expected return code to be FLB_OK")
+	assert.Nil(t, err)
+
+	output.records = make([]*firehose.Record, 0, 500)
+	retCode, err = output.sendCurrentBatch()
+
+	assert.Equal(t, retCode, fluentbit.FLB_OK, "Expected return code to be FLB_OK")
+	assert.Nil(t, err)
+
+}


### PR DESCRIPTION
*Issue #, if available:*
#27 

*Description of changes:*
The plugin was throwing an error when it tries to flush an empty batch. This PR adds an empty check before sending the current batch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
