### PR TITLE
Add supported ECS agent versions for time_key_format in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Run `make` to build `./bin/firehose.so`. Then use with Fluent Bit:
 * `endpoint`: Specify a custom endpoint for the Kinesis Firehose API.
 * `sts_endpoint`: Specify a custom endpoint for the STS API; used to assume your custom role provided with `role_arn`.
 * `time_key`: Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis.
-* `time_key_format`: [strftime](http://man7.org/linux/man-pages/man3/strftime.3.html) compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. If you are running Amazon ECS Container Agent v42.0 or later, you can also use `%L` for milliseconds and `%f` for microseconds.
+* `time_key_format`: [strftime](http://man7.org/linux/man-pages/man3/strftime.3.html) compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. You can also use `%L` for milliseconds and `%f` for microseconds. If you are using ECS FireLens, make sure you are running Amazon ECS Container Agent v1.42.0 or later, otherwise the timestamps associated with your container logs will only have second precision.
 
 ### Permissions
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Run `make` to build `./bin/firehose.so`. Then use with Fluent Bit:
 * `endpoint`: Specify a custom endpoint for the Kinesis Firehose API.
 * `sts_endpoint`: Specify a custom endpoint for the STS API; used to assume your custom role provided with `role_arn`.
 * `time_key`: Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis.
-* `time_key_format`: [strftime](http://man7.org/linux/man-pages/man3/strftime.3.html) compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. You can also use `%L` for milliseconds and `%f` for microseconds.
+* `time_key_format`: [strftime](http://man7.org/linux/man-pages/man3/strftime.3.html) compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. If you are running Amazon ECS Container Agent v42.0 or later, you can also use `%L` for milliseconds and `%f` for microseconds.
 
 ### Permissions
 


### PR DESCRIPTION
*Description of changes:*

I have a Kinesis Firehose that forwards logs to Elasticsearch (on Amazon Elasticsearch Service running v7.7). I am using the `time_key_format` option with `%L` in the format string.

Here's my log configuration:

```
"logConfiguration": {
    "logDriver": "awsfirelens",
    "options": {
    "Name": "firehose",
    "region": "${region}",
    "delivery_stream": "${kinesis_stream_name}",
    "time_key": "timestamp",
    "time_key_format": "%Y-%m-%dT%H:%M:%S.%L"
    }
}
```

Everything is working correctly apart from the fact that I am unable to get the millisecond precision. My log entries look like this:

```
{
    "_index": "ecs_{name}_api-2020-09",
    "_type": "_doc",
    "_id": "49610899033559158379286161472098180728880830833083023362.0",
    "_score": 1,
    "_source": {
        "app_type": "api",
        "container_id": "{container_id}",
        "container_name": "{container_name}",
        "ec2_instance_id": "{instance_id}",
        "ecs_cluster": "default",
        "ecs_task_arn": "arn:aws:ecs:us-east-1:{account_id}:task/6611f18c-e8f7-494d-b62a-3a77802881ec",
        "ecs_task_definition": "{name}:{version}",
        "log": "2020-09-18T06:58:31.699Z --> - 0d801473-0aee-418d-91d1-52b088af09ba GET /ping ::ffff:10.4.4.66",
        "source": "stdout",
        "timestamp": "2020-09-18T06:58:31.000"
    }
}
```

As you can see, the `timestamp` field ends with `000` instead of `699` (or thereabouts). My problem is that I need millisecond precision in my logs.

I have also tried `%Y-%m-%dT%H:%M:%S.%L%z` and `%Y-%m-%dT%H:%M:%S.%f%z`, but both the millisecond and microsecond. I checked the source code and couldn't find any issues with it. I then tried explicitly setting the date format on Elasticsearch (to `strict_date_hour_minute_second_millis`) to no avail.

Then I came across the [PR thread](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit/pull/35#) that implemented this feature, and this [comment](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit/pull/35#issuecomment-661120905) backs up my observation. It turns out that the default configuration for the `fluentd` Docker logging driver has `fluentd-sub-second-precision` to set `false`. I then saw a related [issue](https://github.com/aws/containers-roadmap/issues/839) on [aws/containers-roadmap](https://github.com/aws/containers-roadmap/issues/839) which made a change to FireLens to set it to `true` by default, which suggests this issue has been fixed.

I updated all my ECS Agents to the latest version (44.3) and also Fluent Bit for AWS to 2.7.0, and I was able to get a millisecond-precision timestamp. Thus I want to update the `README.md` to make sure others don't have to spend hours figuring out why `%L` and %f` are not working.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
