### PR TITLE
Add an option to send multiple log events as a record

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Run `make` to build `./bin/firehose.so`. Then use with Fluent Bit:
 * `time_key`: Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis.
 * `time_key_format`: [strftime](http://man7.org/linux/man-pages/man3/strftime.3.html) compliant format string for the timestamp; for example, `%Y-%m-%dT%H:%M:%S%z`. This option is used with `time_key`. You can also use `%L` for milliseconds and `%f` for microseconds. If you are using ECS FireLens, make sure you are running Amazon ECS Container Agent v1.42.0 or later, otherwise the timestamps associated with your container logs will only have second precision.
 * `replace_dots`: Replace dot characters in key names with the value of this option. For example, if you add `replace_dots _` in your config then all occurrences of `.` will be replaced with an underscore. By default, dots will not be replaced.
-
+* `simple_aggregation`: Option to allow plugin send multiple log events in the same record if current record not exceed the maximumRecordSize (1 MiB). It joins together as many log records as possible into a single Firehose record and delimits them with newline. It's good to enable if your destination supports aggregation like S3. Default to be `false`, set to `true` to enable this option.
 ### Permissions
 
 The plugin requires `firehose:PutRecordBatch` permissions.

--- a/fluent-bit-firehose.go
+++ b/fluent-bit-firehose.go
@@ -16,7 +16,6 @@ package main
 import (
 	"C"
 	"unsafe"
-
 	"github.com/aws/amazon-kinesis-firehose-for-fluent-bit/firehose"
 	"github.com/aws/amazon-kinesis-firehose-for-fluent-bit/plugins"
 	"github.com/fluent/fluent-bit-go/output"
@@ -78,12 +77,15 @@ func newFirehoseOutput(ctx unsafe.Pointer, pluginID int) (*firehose.OutputPlugin
 	logrus.Infof("[firehose %d] plugin parameter log_key = '%s'", pluginID, logKey)
 	replaceDots := output.FLBPluginConfigKey(ctx, "replace_dots")
 	logrus.Infof("[firehose %d] plugin parameter replace_dots = '%s'", pluginID, replaceDots)
-
+	simpleAggregation := plugins.GetBoolParam(output.FLBPluginConfigKey(ctx, "simple_aggregation"), false)
+	logrus.Infof("[firehose %d] plugin parameter simple_aggregation = '%v'",
+                  pluginID, simpleAggregation)
 	if deliveryStream == "" || region == "" {
 		return nil, fmt.Errorf("[firehose %d] delivery_stream and region are required configuration parameters", pluginID)
 	}
 
-	return firehose.NewOutputPlugin(region, deliveryStream, dataKeys, roleARN, firehoseEndpoint, stsEndpoint, timeKey, timeKeyFmt, logKey, replaceDots, pluginID)
+	return firehose.NewOutputPlugin(region, deliveryStream, dataKeys, roleARN, firehoseEndpoint, stsEndpoint, timeKey,
+	                                timeKeyFmt, logKey, replaceDots, pluginID, simpleAggregation)
 }
 
 //export FLBPluginInit

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -231,7 +231,8 @@ func contains(s []string, e string) bool {
 	return false
 }
 
-func getBoolParam(param string, defaultVal bool) bool {
+// GetBoolParam is used for boolean config setup
+func GetBoolParam(param string, defaultVal bool) bool {
 	val := strings.ToLower(param)
 	if val == "true" {
 		return true

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -68,10 +68,10 @@ func TestDataKeys(t *testing.T) {
 }
 
 func TestGetBoolParam(t *testing.T) {
-    value1 := getBoolParam("true", false)
+    value1 := GetBoolParam("true", false)
     assert.Equal(t, value1, true, "Expected option value is true")
-    value2 := getBoolParam("false", false)
+    value2 := GetBoolParam("false", false)
     assert.Equal(t, value2, false, "Expected option value is false")
-    value3 := getBoolParam("fakeString", false)
+    value3 := GetBoolParam("fakeString", false)
     assert.Equal(t, value3, false, "Expected option value is false")
 }


### PR DESCRIPTION
Signed-off-by: Drew Zhang <zhayuzhu@amazon.com>

*Issue #:* https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit/issues/12

*Description of changes:*
Add the option for allow multiple log events added in the same record if the maxRecordSizeLimit(1MiB) is not exceeded.

Running result:
```
[ec2-user@ip-172-31-43-210 bin]$ ./fluent-bit -e ./firehose.so -c ~/conf/fluent-bit.conf 
Fluent Bit v1.8.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/03/05 19:32:59] [ info] [engine] started (pid=3702)
[2021/03/05 19:32:59] [ info] [storage] version=1.1.1, initializing...
[2021/03/05 19:32:59] [ info] [storage] in-memory
[2021/03/05 19:32:59] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
INFO[0000] A new higher performance Firehose plugin has been released; you are using the old plugin. Check out the new plugin's documentation and consider migrating.
https://docs.fluentbit.io/manual/pipeline/outputs/firehose 
INFO[0000] [firehose 0] plugin parameter delivery_stream = 'aws-fluent-bit-delivery' 
INFO[0000] [firehose 0] plugin parameter region = 'us-west-2' 
INFO[0000] [firehose 0] plugin parameter data_keys = '' 
INFO[0000] [firehose 0] plugin parameter role_arn = ''  
INFO[0000] [firehose 0] plugin parameter endpoint = ''  
INFO[0000] [firehose 0] plugin parameter sts_endpoint = '' 
INFO[0000] [firehose 0] plugin parameter time_key = ''  
INFO[0000] [firehose 0] plugin parameter time_key_format = '' 
INFO[0000] [firehose 0] plugin parameter log_key = ''   
INFO[0000] [firehose 0] plugin parameter replace_dots = '_' 
INFO[0000] [firehose 0] plugin parameter simple_aggregation = 'true' 
[2021/03/05 19:32:59] [ info] [sp] stream processor started
```
Unit Test: 
```
[ec2-user@ip-172-31-43-210 amazon-kinesis-firehose-for-fluent-bit]$ make test
go test -timeout=120s -v -cover ./...
?   	github.com/aws/amazon-kinesis-firehose-for-fluent-bit	[no test files]
=== RUN   TestAddRecord
--- PASS: TestAddRecord (0.00s)
=== RUN   TestAddRecordWithMultipleLogEventsPerRecordEnable
--- PASS: TestAddRecordWithMultipleLogEventsPerRecordEnable (0.00s)
=== RUN   TestTruncateLargeLogEvent
time="2021-03-05T17:12:17Z" level=warning msg="[firehose 0] Found record with 6144045 bytes, truncating to 1000Kib, stream=stream\n"
time="2021-03-05T17:12:17Z" level=warning msg="[firehose 0] Found record with 6144045 bytes, truncating to 1000Kib, stream=stream\n"
--- PASS: TestTruncateLargeLogEvent (0.05s)
=== RUN   TestAddRecordAndFlush
--- PASS: TestAddRecordAndFlush (0.00s)
=== RUN   TestSendCurrentBatch
--- PASS: TestSendCurrentBatch (0.00s)
=== RUN   TestDotReplace
--- PASS: TestDotReplace (0.00s)
PASS
coverage: 33.6% of statements
ok  	github.com/aws/amazon-kinesis-firehose-for-fluent-bit/firehose	(cached)	coverage: 33.6% of statements
?   	github.com/aws/amazon-kinesis-firehose-for-fluent-bit/firehose/mock_firehose	[no test files]
=== RUN   TestDecodeMap
--- PASS: TestDecodeMap (0.00s)
=== RUN   TestDataKeys
--- PASS: TestDataKeys (0.00s)
=== RUN   TestGetBoolParam
--- PASS: TestGetBoolParam (0.00s)
PASS
coverage: 38.8% of statements
ok  	github.com/aws/amazon-kinesis-firehose-for-fluent-bit/plugins	(cached)	coverage: 38.8% of statements
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
