### PR TITLE
[Windows support for fluent-bit] added targets in makefile to build Windows artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
         go-version: 1.17
       id: go
 
+    - name: Install cross-compiler for Windows
+      run: sudo apt-get install -y gcc-multilib gcc-mingw-w64
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
@@ -26,4 +29,4 @@ jobs:
       run: go get -u golang.org/x/lint/golint
 
     - name: Build
-      run: make build test
+      run: make build windows-release test

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+# Build settings.
+GOARCH ?= amd64
+COMPILER ?= x86_64-w64-mingw32-gcc # Cross-compiler for Windows
+
 ROOT := $(shell pwd)
 
 all: build
@@ -33,6 +37,12 @@ release:
 	mkdir -p ./bin
 	go build -buildmode c-shared -o ./bin/firehose.so ./
 	@echo "Built Amazon Kinesis Data Firehose Fluent Bit Plugin"
+
+.PHONY: windows-release
+windows-release:
+	mkdir -p ./bin
+	GOOS=windows GOARCH=$(GOARCH) CGO_ENABLED=1 CC=$(COMPILER) go build -buildmode c-shared -o ./bin/firehose.dll ./
+	@echo "Built Amazon Kinesis Data Firehose Fluent Bit Plugin for Windows"
 
 .PHONY: generate
 generate: $(SOURCES)

--- a/README.md
+++ b/README.md
@@ -16,9 +16,20 @@ Run `make` to build `./bin/firehose.so`. Then use with Fluent Bit:
 ./fluent-bit -e ./firehose.so -i cpu \
 -o firehose \
 -p "region=us-west-2" \
--p "delivery-stream=example-stream"
+-p "delivery_stream=example-stream"
 ```
 
+For building Windows binaries, we need to install `mingw-64w` for cross-compilation. The same can be done using-
+```
+sudo apt-get install -y gcc-multilib gcc-mingw-w64
+```
+After this step, run `make windows-release` to build `./bin/firehose.dll`. Then use with Fluent Bit on Windows:
+```
+./fluent-bit.exe -e ./firehose.dll -i dummy `
+-o firehose `
+-p "region=us-west-2" `
+-p "delivery_stream=example-stream"
+```
 ### Plugin Options
 
 * `region`: The region which your Firehose delivery stream(s) is/are in.


### PR DESCRIPTION
## Summary
In order to build Windows artifacts, we have added a separate target for the same in Makefile. We are using a cross-compiler to build Windows artifacts.

Additionally, we have added the same to Github action on PR.

To ensure that customers building their own plugins can build Windows artifacts for different architectures and using different cross-compilers, the build settings are customisable.

Please note that we have not modified the existing targets or added Windows target to `build` target. This is because in order to build Windows artifacts, we need to install cross-compiler which by default is not available on most runtimes. Therefore, adding a separate Windows target ensures backward-compatibility.

## Testing
Installed the cross-compiler on an Ubuntu machine and then ran `make windows-release`
Then tested the built plugin with fluent-bit on Windows instance to ensure that the logs are received in S3 via Firehose (as configured).

## Issue #, if available:
N/A

## Description of changes:
added a target for Windows release in makefile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
